### PR TITLE
Steves ptt

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ Override the model:
 WHISPER_MODEL=ggml-base.en-q5_0.bin ./scripts/install_whisper.sh
 ```
 
+> **macOS / Linux note — manual builds.** The install script copies the built binary to `whisper/whisper-server`, which is where PAM looks for it. If you build whisper.cpp by hand (e.g., `cmake` directly in a checkout you placed under `whisper/`), the binary lands at `whisper/build/bin/whisper-server` instead and PAM won't find it. Either re-run the script from a clean `whisper/` directory, or symlink the existing binary into place **from the PAM project root** so the relative target resolves correctly:
+> ```bash
+> ln -s build/bin/whisper-server whisper/whisper-server
+> ```
+> Running that command from inside `whisper/` (or with `whisper/build/bin/whisper-server` as the target) creates a dangling symlink — target paths are resolved relative to the symlink's own directory, not your shell's.
+>
+> Also: whatever you set `WHISPER_MODEL` to (in `.env` or your shell environment) must match the model filename **exactly**. `ggml-base.en.bin` and `ggml-base.en-q5_0.bin` are different files; a typo here surfaces as the same "model not found" error as a missing download.
+
 ### 3. Run
 
 ```bash
@@ -250,10 +258,98 @@ Full layout and contributing guide: see [`CLAUDE.md`](CLAUDE.md) and [`CONTRIBUT
 ## Troubleshooting
 
 - **Mic button greyed out** — your browser needs HTTPS on a non-localhost origin. PAM's auto-generated cert should handle this; if not, run `./scripts/generate_cert.sh`.
-- **"Whisper binary not found"** — make sure `whisper-server.exe` sits directly inside the `whisper\` folder (not in a `Release\` subfolder) and that the model file is at `whisper\models\<model-name>.bin`. See step 2 of the install for the expected layout.
+- **"Whisper binary not found"** — the binary must sit directly inside the `whisper/` folder.
+  - **Windows:** `whisper\whisper-server.exe` (not inside a `Release\` subfolder — move it up one level if needed).
+  - **macOS / Linux:** `whisper/whisper-server`. If you built whisper.cpp manually, it's likely at `whisper/build/bin/whisper-server` — symlink it into place from the PAM project root: `ln -s build/bin/whisper-server whisper/whisper-server`. Symlink targets are relative to the symlink's directory, so running that `ln` from the wrong directory produces a dangling symlink.
+  - Also verify the model file exists at `whisper/models/<model-name>.bin` and that `WHISPER_MODEL` (in `.env` or your shell environment) matches the filename on disk **exactly** — one missing hyphen or suffix yields the same error.
 - **`cmake is not recognized` / `'cl' is not recognized` when running `install_whisper.ps1`** — you're trying to build from source without the toolchain. On Windows, use the pre-built binary path (step 2, Option A) instead — no compiler needed.
 - **Briefing returns empty / no AI** — check `claude --print -p "hi"` on the host. If it fails, the CLI isn't set up.
 - **`GET /health`** returns per-integration status — use this to diagnose what's wired and what isn't.
+
+---
+
+### Voice (Push-to-talk)
+
+Hold a single key anywhere in the PAM browser tab to record a voice note. When
+you release the key, PAM transcribes it via whisper and:
+
+- Shows the transcript in the voice panel's result card, with a **Copy** button
+  to put it on your clipboard on demand.
+- Logs it to the voice history (`voice_log` table in SQLite).
+- Offers **Add as To-Do** and **Send as PAM Task** buttons next to the
+  transcript for one-click routing.
+
+#### How to use it
+
+1. Open PAM in your browser (e.g., `https://localhost:8400`). Accept the
+   self-signed certificate the first time.
+2. Grant the browser microphone permission when prompted. This only needs to
+   happen once per browser profile.
+3. **Hold down the backtick key** — the `` ` `` key, typically just above
+   Tab on US keyboards, sharing a key with `~`.
+4. Speak while holding the key. You'll hear a short sound effect confirming
+   recording has started, and the voice panel's waveform animates.
+5. **Release the key** to stop recording. A second sound effect plays, PAM
+   sends the audio to whisper, and the transcript appears in the voice panel's
+   result card.
+6. Click **Copy** on the result card to put the transcript on your clipboard,
+   then paste (`Cmd+V` / `Ctrl+V`) anywhere. Or use **Add as To-Do** /
+   **Send as PAM Task** to route it without leaving PAM.
+7. **Oops, didn't mean to start?** Press **Escape** while still holding
+   backtick to cancel — the recording is discarded and nothing is sent to
+   whisper.
+
+#### Tips
+
+- **PTT is tab-local.** It only works while the PAM tab is focused in your
+  browser. Click into the PAM tab before holding backtick. A system-wide PTT
+  would require a native helper app and is intentionally out of scope.
+- **Backtick still types normally in text fields.** If your cursor is in a
+  text input, textarea, or other editable field, pressing backtick will type
+  the character as usual — PTT is suppressed so you don't accidentally start
+  recording while editing a note. Click outside the input first to use PTT.
+- **Hold, don't tap.** PTT is hold-to-talk: release ends the recording.
+  Holds shorter than ~200ms are treated as accidental taps and discarded
+  without being sent to whisper — so a stray finger brush won't queue a
+  useless empty transcription.
+- **Audio feedback is non-visual on purpose.** You hear a confirming sound
+  on start, on successful stop, and a distinct "canceled" sound on abort
+  (escape-cancel or too-short tap). That lets you use PTT without looking
+  at the PAM tab. Turn sounds off via PAM's settings if you prefer silence.
+- **The mic button still works.** Clicking the microphone button in the voice
+  panel behaves exactly as before — click once to start, click again to stop.
+  PTT is an addition, not a replacement.
+- **Clipboard is opt-in.** PAM will not overwrite your clipboard
+  automatically — the transcript only lands there when you click **Copy** on
+  the result card. This keeps anything you already had copied safe.
+
+#### Troubleshooting
+
+**Nothing happens when I hold backtick.**
+
+- Confirm the PAM browser tab is focused (click somewhere on the PAM page
+  first, outside any text input).
+- Confirm you granted microphone permission. Check the site settings
+  (padlock icon in the address bar) if you're not sure.
+- Open devtools → Console and check for errors while holding the key.
+
+**I pressed backtick in a note and it started recording.**
+
+- It shouldn't — PTT is suppressed inside inputs, textareas, and
+  `contenteditable="true"` elements. If you hit a field where it still
+  triggers, that's a bug; file an issue with the element type.
+
+**I held the key briefly and nothing happened.**
+
+- This is by design. Holds shorter than ~200ms are treated as accidental
+  taps. Hold a little longer next time. Minimum hold is tuned via
+  `PTT_MIN_HOLD_MS` in `frontend/pam.js`.
+
+**I want to change the hotkey or the minimum-hold duration.**
+
+- Not exposed as settings yet. The key is defined as `PTT_KEY` and the
+  minimum hold as `PTT_MIN_HOLD_MS` near the top of the voice section in
+  `frontend/pam.js`; edit the values there and reload the page.
 
 ---
 

--- a/frontend/pam.js
+++ b/frontend/pam.js
@@ -689,6 +689,7 @@ async function startRecording() {
     mediaRecorder.onstop = async () => {
       stream.getTracks().forEach(t => t.stop());
       stopVisualizer();
+      if (pttAbort) { pttAbort = false; return; }
       const blob = new Blob(audioChunks, { type: mediaRecorder.mimeType });
       await sendAudio(blob, 'recording.webm');
     };
@@ -722,6 +723,44 @@ function stopRecording() {
     timer.style.display = 'none'; waveform.style.display = 'none';
   }
 }
+
+// ─── Push-to-talk (hold backtick) ──────────────────
+const PTT_KEY = '`';
+const PTT_MIN_HOLD_MS = 200;
+let pttActive = false;
+let pttStartTime = 0;
+let pttAbort = false;
+
+document.addEventListener('keydown', async (e) => {
+  if (e.key === 'Escape' && pttActive) {
+    pttAbort = true;
+    pttActive = false;
+    stopRecording();
+    playSFX('delete');
+    return;
+  }
+  if (e.key !== PTT_KEY || e.repeat || pttActive) return;
+  const t = e.target;
+  if (t.matches && t.matches('input, textarea, [contenteditable="true"]')) return;
+  e.preventDefault();
+  pttActive = true;
+  pttAbort = false;
+  pttStartTime = Date.now();
+  playSFX('utility');
+  await startRecording();
+});
+
+document.addEventListener('keyup', (e) => {
+  if (e.key !== PTT_KEY || !pttActive) return;
+  pttActive = false;
+  if (Date.now() - pttStartTime < PTT_MIN_HOLD_MS) {
+    pttAbort = true;
+    playSFX('delete');
+  } else {
+    playSFX('utility');
+  }
+  stopRecording();
+});
 
 function getSupportedMime() {
   for (const t of ['audio/webm;codecs=opus','audio/webm','audio/ogg','audio/mp4'])


### PR DESCRIPTION
## Summary

  Adds an in-tab push-to-talk (PTT) hotkey to the voice panel, documents how to use it, and files two design docs for follow-up work that surfaced during the exercise. No backend changes, no new runtime dependencies.

  ## What changed

  ### Feature — in-tab push-to-talk (`frontend/pam.js`)

  Hold backtick anywhere in the PAM tab (outside text inputs) to record; release to transcribe. Release triggers the existing `/voice/transcribe` pipeline unchanged — transcript still displays in the result card, logs to `voice_log`, and refreshes voice history.

  Four focused additions, each justified by a specific UX concern:

  - **Keydown/keyup listeners** bound to a `PTT_KEY = '`'` constant. Guards against OS key-repeat, active-recording reentrance, and firing inside `input` / `textarea` / `contenteditable` elements so backtick still types normally in notes.
  - **Audio feedback** via the existing `playSFX('utility')` on start and normal stop, `playSFX('delete')` on abort paths. Lets the user dictate without watching the PAM tab — the waveform alone isn't useful when another app is focused.
  - **Minimum-hold guard** (`PTT_MIN_HOLD_MS = 200`). Holds shorter than 200ms are treated as accidental taps and discarded without firing a whisper call. Stray keypresses no longer queue empty transcriptions.
  - **Escape-to-cancel.** Pressing Escape while PTT is active aborts the recording cleanly — MediaRecorder stops, stream tracks close, visualizer tears down, but `sendAudio` is skipped via a new `pttAbort` flag checked inside `mediaRecorder.onstop`. Scoped to PTT-initiated
  recordings only, so mic-button click-to-record is untouched.

  The auto-copy-to-clipboard behavior originally in the plan was **removed before merge** — it would have silently overwritten the user's clipboard on every recording (including ones initiated via the mic button and file upload, which used to be clipboard-safe). The existing
   result-card Copy button already covers the on-demand case.

  ### Docs — `USER_GUIDE.md` (new)

  New end-user guide at the project root, scaffolded with a table-of-contents pattern for future sections. Currently populated with a single **Push-to-talk (voice capture)** section covering usage, tips (tab-local, hold-don't-tap, backtick-in-inputs, clipboard-is-opt-in,
  audio-feedback-is-intentional), and troubleshooting.

  ### Docs — `README.md` (updates)

  Two targeted notes, prompted by a real issue hit while testing on macOS:

  - **Step 2 / Option B (Build from source)**: macOS/Linux callout explaining that a manual `cmake` build lands the binary at `whisper/build/bin/whisper-server`, which isn't where PAM looks. Includes the symlink recipe and a warning about dangling relative symlinks when `ln
  -s` is run from the wrong directory.
  - **Troubleshooting / "Whisper binary not found"**: rewrote the Windows-only entry into three platform-aware bullets (Windows / macOS-Linux / model filename matching).

  ### Design docs — `dev_docs/` (new directory)

  - **`dev_docs/GLOBAL_PTT_PLAN.md`** — implementation plan for an optional standalone Python helper (`pynput` + `sounddevice` + `pyperclip`) that would provide OS-global PTT by capturing audio directly and POSTing to the existing `/voice/transcribe` endpoint. Reuses backend
   verbatim — no new routes, no DB changes. Includes CLI surface, cross-platform notes, three autostart examples (launchd/systemd/bat), security considerations, four-phase rollout, and explicit out-of-scope items. **Not implemented in this PR.**
  - **`dev_docs/WHISPER_MACOS_FIX_PLAN.md`** — diagnosis + fix plan for a pre-existing bug surfaced while testing: `app/config.py` hard-codes a single path for the whisper binary, and the error at `app/services/whisper.py:159` has `.exe` baked into the message. Affects any
  non-Windows user whose binary landed outside the canonical `whisper/whisper-server` path. Proposes a three-commit fix (multi-path binary discovery, accurate error messages, install-script hardening) with unit-test sketches and a cross-platform manual test matrix. **Not
  implemented in this PR** — scoped out to keep this change focused.

  ## Why this scope

  The core feature (in-tab PTT) is ~35 lines of JavaScript and reuses the voice pipeline that already existed. The interesting work in this PR was:

  - **Owning the clipboard regression.** The original plan included auto-copy-on-success; during review we realized it would clobber the user's clipboard on every recording path, not just PTT. Reverted that half of the feature and left a tip in the user guide explaining why
  the Copy button is explicitly on-demand.
  - **Making PTT actually usable without looking at the tab.** Audio feedback + min-hold + escape-to-cancel transform this from a keyboard shortcut for the mic button (marginal value) into a reasonable dictation flow.
  - **Capturing the follow-up work that surfaced mid-task.** An OS-global PTT helper is the change that would make "PTT" a real feature rather than a shortcut — but it's a native process, separate concerns, and deserves its own PR. Same for the whisper path-resolution bug,
  which is orthogonal and affects users who never touch the PTT feature. Both plans are detailed enough to execute without re-deriving the design.

  ## What's NOT in this PR

  - **OS-global PTT helper** — `dev_docs/GLOBAL_PTT_PLAN.md` describes the design; no code added.
  - **Whisper binary path-resolution fix** — `dev_docs/WHISPER_MACOS_FIX_PLAN.md` describes the defect + fix. Local installs can unblock with a symlink and a `WHISPER_MODEL` override as documented in the README; the proper multi-path discovery change is deferred.
  - **Configurable PTT hotkey via Settings UI** — still requires editing `PTT_KEY` in `pam.js` and reloading. Called out in USER_GUIDE troubleshooting.
  - **Tests.** The project has none today; introducing a framework for ~35 lines of JS wasn't proportional. The design docs flag a `tests/` directory as acceptable when the follow-up work (PTT helper, whisper resolver) lands.

  ## Test plan

  - [ ] Focus the PAM tab, hold backtick, speak, release — transcript appears in the result card, logs to voice history, start/stop SFX play.
  - [ ] Tap backtick very briefly (<200ms) — no whisper call fires (check devtools Network tab), "canceled" SFX plays.
  - [ ] Hold backtick, press Escape while still holding — recording aborts without `sendAudio`, "canceled" SFX plays.
  - [ ] Focus a text input (todo add, note editor), press backtick — character types normally, no recording.
  - [ ] Click the mic button to record normally — behaves exactly as before (no PTT side effects, no clipboard write).
  - [ ] Upload an audio file via drag-drop — transcribes normally (no clipboard write).
  - [ ] `node --check frontend/pam.js` passes.

  ## Files

  **Modified:**
  - `frontend/pam.js` — PTT block + `mediaRecorder.onstop` abort check
  - `README.md` — macOS build note in Option B, rewritten whisper-not-found troubleshooting entry

  **Added:**
  - `USER_GUIDE.md` — user-facing guide, PTT section populated
  - `dev_docs/GLOBAL_PTT_PLAN.md` — follow-up design doc (not implemented)
  - `dev_docs/WHISPER_MACOS_FIX_PLAN.md` — follow-up diagnosis doc (not implemented)